### PR TITLE
Support for Nix 2.4

### DIFF
--- a/extra-builtins.cc
+++ b/extra-builtins.cc
@@ -46,13 +46,11 @@ static void extraBuiltins(EvalState & state, const Pos & _pos,
 
             auto sExec = state.symbols.create("exec");
             auto vExec = state.allocAttr(*arg, sExec);
-            vExec->type = tPrimOp;
-            vExec->primOp = new PrimOp { .fun = prim_exec, .arity = 1, .name = sExec};
+            vExec->mkPrimOp(new PrimOp { .fun = prim_exec, .arity = 1, .name = sExec});
 
             auto sImportNative = state.symbols.create("importNative");
             auto vImportNative = state.allocAttr(*arg, sImportNative);
-            vImportNative->type = tPrimOp;
-            vImportNative->primOp = new PrimOp { .fun = prim_importNative, .arity = 2, .name = sImportNative };
+            vImportNative->mkPrimOp(new PrimOp { .fun = prim_importNative, .arity = 2, .name = sImportNative });
 
             arg->attrs->sort();
         }

--- a/extra-builtins.cc
+++ b/extra-builtins.cc
@@ -18,7 +18,7 @@ using namespace nix;
 
 struct ExtraBuiltinsSettings : Config {
     Setting<Path> extraBuiltinsFile{this,
-        settings.nixConfDir + "/extra-builtins.nix",
+        fmt("%s/%s", settings.nixConfDir, "extra-builtins.nix"),
             "extra-builtins-file",
             "The path to a nix expression defining extra expression-language level builtins."};
 };

--- a/extra-builtins.cc
+++ b/extra-builtins.cc
@@ -69,9 +69,9 @@ static void cflags(EvalState & state, const Pos & _pos,
     Value ** _args, Value & v)
 {
     state.mkAttrs(v, 3);
-    mkStringNoCopy(*state.allocAttr(v, state.symbols.create("NIX_INCLUDE_DIRS")), NIX_INCLUDE_DIRS);
-    mkStringNoCopy(*state.allocAttr(v, state.symbols.create("NIX_CFLAGS_OTHER")), NIX_CFLAGS_OTHER);
-    mkStringNoCopy(*state.allocAttr(v, state.symbols.create("BOOST_INCLUDE_DIR")), BOOST_INCLUDE_DIR);
+    mkString(*state.allocAttr(v, state.symbols.create("NIX_INCLUDE_DIRS")), NIX_INCLUDE_DIRS);
+    mkString(*state.allocAttr(v, state.symbols.create("NIX_CFLAGS_OTHER")), NIX_CFLAGS_OTHER);
+    mkString(*state.allocAttr(v, state.symbols.create("BOOST_INCLUDE_DIR")), BOOST_INCLUDE_DIR);
 }
 
 static RegisterPrimOp rp2("__nix-cflags", 0,

--- a/extra-builtins.cc
+++ b/extra-builtins.cc
@@ -47,12 +47,12 @@ static void extraBuiltins(EvalState & state, const Pos & _pos,
             auto sExec = state.symbols.create("exec");
             auto vExec = state.allocAttr(*arg, sExec);
             vExec->type = tPrimOp;
-            vExec->primOp = new PrimOp(prim_exec, 1, sExec);
+            vExec->primOp = new PrimOp { .fun = prim_exec, .arity = 1, .name = sExec};
 
             auto sImportNative = state.symbols.create("importNative");
             auto vImportNative = state.allocAttr(*arg, sImportNative);
             vImportNative->type = tPrimOp;
-            vImportNative->primOp = new PrimOp(prim_importNative, 2, sImportNative);
+            vImportNative->primOp = new PrimOp { .fun = prim_importNative, .arity = 2, .name = sImportNative };
 
             arg->attrs->sort();
         }


### PR DESCRIPTION
This may not be appropriate to merge, since nix 2.4 is not stable, but I felt that a draft PR might be helpful for others trying to use nix-plugins with nix 2.4.

Please note that this code is NOT my own, appologies to @dguibert's whose [dotfiles](https://github.com/dguibert/dotfiles/blob/f530a82ff250b857495b7684a9bfe6e77ec25b5d/admin/nixops/flake.nix#L228-L242) lead me to the patches.

Testing that it works, with the following `shell.nix` file:

```nix
{ pkgs ?
    import <nixpkgs> {
      overlays = [ (self: super: {
        nix =
          self.nixFlakes;

        nix-plugins =
          (super.nix-plugins.override { nix = self.nixFlakes; }).overrideAttrs
            (oldAttrs: {
              src = self.fetchFromGitHub {
                owner = "rehno-lindeque";
                repo = "nix-plugins";
                rev = "524c6c29e4e340ec0c2440b878507983339b65df";
                sha256 = "0xi3bs8j9zc5hpv10jys95mc1w4933cbyiraxl7s9by6rl42dmmm";
              };
              buildInputs = oldAttrs.buildInputs ++ [ self.nlohmann_json ];
            });
      })];
    }
}:

let
  now = pkgs.writeScript "now.sh" ''
    printf '"' && (date +%Y-%m-%d | tr -d '\n') && printf '"'
  '';
  example-builtins = pkgs.writeText "example-builtins.nix" ''
    { exec, ... }:

    {
      now = exec [ "${now}" "+%Y-%m-%d" ];
    }
  '';
in
pkgs.mkShell {
  buildInputs = with pkgs; [
    nix
    nix-plugins
  ];
  shellHook =
    with pkgs;
    ''
      echo 'nixpkgs: ${lib.version}'

      nix \
        --option plugin-files ${nix-plugins}/lib/nix/plugins/libnix-extra-builtins.so \
        --option extra-builtins-file ${example-builtins} \
        eval \
        --expr 'builtins.seq builtins.extraBuiltins builtins.extraBuiltins.now'
    '';
}
```

```
$ nix-shell shell.nix 
nixpkgs: 21.05.1669.973910f5c31
"2021-07-26"
```