### PR TITLE
Force function application before returning extraBuiltins

### DIFF
--- a/extra-builtins.cc
+++ b/extra-builtins.cc
@@ -55,6 +55,7 @@ static void extraBuiltins(EvalState & state, const Pos & _pos,
             arg->attrs->sort();
         }
         mkApp(v, *fun, *arg);
+        state.forceAttrs(v, _pos);
     } catch (SysError & e) {
         if (e.errNo != ENOENT)
             throw;


### PR DESCRIPTION
Before this commit builtins.extraBuiltins couldn't be used without
manually introducing strictness via seq or let binding.

The error nix reported was

```
error: value is a function application while a set was expected
```
