### PR TITLE
drop the fast path for enableNativeCode == true

### DIFF
--- a/extra-builtins.cc
+++ b/extra-builtins.cc
@@ -39,28 +39,24 @@ static void extraBuiltins(EvalState & state, const PosIdx pos,
         auto fun = state.allocValue();
         state.evalFile(extraBuiltinsFile, *fun);
         Value * arg;
-        if (evalSettings.enableNativeCode) {
-            arg = state.baseEnv.values[0];
-        } else {
-            auto attrs = state.buildBindings(2);
+        auto attrs = state.buildBindings(2);
 
-            auto sExec = state.symbols.create("exec");
-            attrs.alloc(sExec).mkPrimOp(new PrimOp {
-                .name = "exec",
-                .arity = 1,
-                .fun = prim_exec,
-            });
+        auto sExec = state.symbols.create("exec");
+        attrs.alloc(sExec).mkPrimOp(new PrimOp {
+            .name = "exec",
+            .arity = 1,
+            .fun = prim_exec,
+        });
 
-            auto sImportNative = state.symbols.create("importNative");
-            attrs.alloc(sImportNative).mkPrimOp(new PrimOp {
-                .name = "importNative",
-                .arity = 2,
-                .fun = prim_importNative,
-            });
+        auto sImportNative = state.symbols.create("importNative");
+        attrs.alloc(sImportNative).mkPrimOp(new PrimOp {
+            .name = "importNative",
+            .arity = 2,
+            .fun = prim_importNative,
+        });
 
-            arg = state.allocValue();
-            arg->mkAttrs(attrs);
-        }
+        arg = state.allocValue();
+        arg->mkAttrs(attrs);
         v.mkApp(fun, arg);
         state.forceValue(v, pos);
     } catch (SysError & e) {


### PR DESCRIPTION
This caused issues when Nix was used as a library, because eval settings are only present in the binary.

For example, Hydra (among other things) errored out like this:

```
error: could not dynamically open plugin file '"/nix/store/2jr1wzy4ph2pv0h9fzpw1375ywbh6psl-nix-plugins-15.0.0/lib/nix/plugins/libnix-extra-builtins.so"':  /nix/store/2jr1wzy4ph2pv0h9fzpw1375ywbh6psl-nix-plugins-15.0.0/lib/nix/plugins/libnix-extra-builtins.so: undefined symbol: _ZN3nix12evalSettingsE
```