### PR TITLE
nix 2.33+ patch

### DIFF
--- a/extra-builtins.cc
+++ b/extra-builtins.cc
@@ -72,9 +72,9 @@ static void cflags(EvalState & state, const PosIdx _pos,
     Value ** _args, Value & v)
 {
     auto attrs = state.buildBindings(3);
-    attrs.alloc("NIX_INCLUDE_DIRS").mkString(NIX_INCLUDE_DIRS);
-    attrs.alloc("NIX_CFLAGS_OTHER").mkString(NIX_CFLAGS_OTHER);
-    attrs.alloc("BOOST_INCLUDE_DIR").mkString(BOOST_INCLUDE_DIR);
+    attrs.alloc("NIX_INCLUDE_DIRS").mkString(NIX_INCLUDE_DIRS, state.mem);
+    attrs.alloc("NIX_CFLAGS_OTHER").mkString(NIX_CFLAGS_OTHER, state.mem);
+    attrs.alloc("BOOST_INCLUDE_DIR").mkString(BOOST_INCLUDE_DIR, state.mem);
     v.mkAttrs(attrs);
 }
 


### PR DESCRIPTION
In NixOS/nix#14584 mkString was changed to require an `EvalMemory`, part of a larger effort to centralize memory allocation.

Disclaimer: Claude wrote this patch. While I am a software developer I'm not a C++ developer, nor do I have a lot of experience with Nix (yet). I just wanted to contribute back the fix.